### PR TITLE
refactor: dont emit modified during mint

### DIFF
--- a/src/NFTPermissions.sol
+++ b/src/NFTPermissions.sol
@@ -105,7 +105,7 @@ abstract contract NFTPermissions is ERC721, EIP712, INFTPermissions {
 
   /**
    * @notice Mints a new position with the assigned permissions
-   * @dev Please not that this function does not emit an event with the new assigned permissions. It's up to each contract to then
+   * @dev Please note that this function does not emit an event with the new assigned permissions. It's up to each contract to then
    *      emit an event with the permissions, plus any other data they want
    * @param _owner The owner of the new position
    * @param _permissions The permissions to assign to the position

--- a/test/unit/NFTPermissions.t.sol
+++ b/test/unit/NFTPermissions.t.sol
@@ -190,9 +190,6 @@ contract NFTPermissionsTest is PRBTest, StdUtils {
     INFTPermissions.PermissionSet[] memory _permissionSet = new INFTPermissions.PermissionSet[](1);
     _permissionSet[0] = INFTPermissions.PermissionSet({ operator: operator1, permissions: Utils.permissions(PERMISSION_1) });
 
-    vm.expectEmit();
-    emit ModifiedPermissions(1, _permissionSet);
-
     uint256 _positionId = nftPermissions.mintWithPermissions(owner, _permissionSet);
 
     assertEq(_positionId, 1);


### PR DESCRIPTION
We are making a change so that `ModifiedPermissions` is no longer emitted during mint. 

_Note: it will be up to contracts that use NFTPermissions to emit this information during mint_